### PR TITLE
Ensure nuget.config file is mandatory to perform the build

### DIFF
--- a/Build.bat
+++ b/Build.bat
@@ -65,6 +65,13 @@ Rem Error check
 echo CLEAN %CLEAN%
 echo FULL_BUILD %FULL_BUILD%
 echo INCREMENTAL_BUILD %INCREMENTAL_BUILD%
+
+Rem Pre-requisites check
+if not exist "%SCRIPT_DIR%nuget.config" (
+    echo "The file 'nuget.config' is missing at root directory. See 'nuget.config.template' for sample file"
+    goto error
+)
+
 REM TODO:
 REM Build --full --incremental does not cates below error
 if "%INCREMENTAL_BUILD%" EQU "true" if "%FULL_BUILD%" EQU "true" (
@@ -88,9 +95,9 @@ if errorlevel 1 goto error
 
 Rem TODO: Publish to be performed
 
-echo Build succeeded
+Powershell Write-host -BackgroundColor Green "Build succeeded"
 goto :eof
 
 :error
-echo Build failed
+Powershell Write-host -BackgroundColor Red "Build failed"
 exit /b 1

--- a/nuget.config.template
+++ b/nuget.config.template
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <clear />
+        <add key="github" value="https://nuget.pkg.github.com/vishalgr/index.json" />
+        <add key="NuGet v2" value="https://www.nuget.org/api/v2/" />
+    </packageSources>
+    <packageSourceCredentials>
+        <github>
+            <add key="Username" value="<ENTER YOUR GIT USER NAME HERE. EX: vishalgr>" />
+            <add key="ClearTextPassword" value="<ENTER THE CREDENTIAL PASS KEY TO ACCESS TO THE REGISSTRY. Typically 40char string>" />
+        </github>
+    </packageSourceCredentials>
+</configuration>


### PR DESCRIPTION
Simple logic  is in place now to ensure Nuget.Config file should be generated before starting the build and a sample file for the same is provided.